### PR TITLE
prefer stable branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL com.github.actions.icon="terminal"
 LABEL com.github.actions.color="gray-dark"
 
 RUN apk add --no-cache curl bash libstdc++
-RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | bash
+RUN curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | bash
 
 COPY LICENSE README.md /
 COPY "entrypoint.sh" "/entrypoint.sh"


### PR DESCRIPTION
The master branch contains a `| sed ...` command that broke my CI pipeline earlier today. This PR prefers the `stable` branch (no `|sed`)

