### PR TITLE
Allow give the hasura cli version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This Action for [Hasura](https://hasura.io) enables arbitrary actions with the `
 
 - `HASURA_WORKDIR` - **Optional**. The path from the root of your repository to the directory where the `migrations` folder can be found.
 
+- `HASURA_ENGINE_VERSION` - **Optional**. The version of the hasura cli you want to use. (default is `stable`)
+
 ## Example
 
 To apply migrations with the Hasura CLI:
@@ -39,6 +41,7 @@ jobs:
           HASURA_ENDPOINT: ${{ secrets.HASURA_ENDPOINT }}
           HASURA_ADMIN_SECRET: ${{ secrets.HASURA_ADMIN_SECRET }}
           HASURA_WORKDIR: backend/hasura # replace this by your own path if needed
+          HASURA_ENGINE_VERSION: v1.3.3 # replace this by the version you need, remove to use stable
 ```
 
 ## License

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,11 @@ if [ ! -f config.yaml ]; then
     touch config.yaml
 fi
 
+if [ -n "$HASURA_ENGINE_VERSION" ]; then
+    hasura update-cli --version $HASURA_ENGINE_VERSION
+fi
+
+
 # secrets can be printed, they are protected by Github Actions
 echo "Executing $command from ${HASURA_WORKDIR:-./}"
 


### PR DESCRIPTION
Issue:
 - Project is working with `Hasura GraphQL Engine 2.0.0-alpha.10` but the hasura cli running the `stable` version.

Solution: 
- Can be given by environment variable the hasura cli version that need so for this was created the env `HASURA_ENGINE_VERSION`.